### PR TITLE
Fix region_name parsing in elf32-extmap

### DIFF
--- a/bfd/elf32-extmap.c
+++ b/bfd/elf32-extmap.c
@@ -1,6 +1,7 @@
 /* extended map support for elf format
    Copyright  2011 Free Software Foundation, Inc.
    Contributed by Horst Lehser (Horst.Lehser@hightec-rt.com).
+   Extended by Domenico Iezzi (domenico@iezzi.info).
 
    This file is part of BFD, the Binary File Descriptor library.
 
@@ -242,16 +243,13 @@ elf32_extmap_add_sym (struct bfd_link_hash_entry *entry, void * link_info ATTRIB
   return true;
 }
 
-/* The initial part of tricore_user_section_struct has to be identical with
-   fat_user_section_struct from ld.h  */
+/* The initial part of tricore_user_section_struct has to mimic
+   lang_output_section_statement_type from ld/ldlang.h. After 64 bytes,
+   we have a pointer to lang_memory_region_type, which contains the region name as first element */
 typedef struct tricore_user_section_struct {
-  void *head;
-  void *tail;
-  unsigned long count;
-  const char *region_name;
-  const flagword region_flags;
+  int unused[16];
+  const char **region_name;
 } tricore_section_userdata_type;
-
 
 void
 elf32_collect_extmap_info (struct bfd_link_info* info,
@@ -362,7 +360,7 @@ elf32_collect_extmap_info (struct bfd_link_info* info,
 	  tricore_section_userdata_type *ud;
           ud = bfd_section_userdata(sym->section->output_section);
           if (ud)
-            sym->region_name = ud->region_name;
+            sym->region_name = *ud->region_name;
           else
             sym->region_name = "NOREGION";
         }

--- a/bfd/elf32-extmap.c
+++ b/bfd/elf32-extmap.c
@@ -247,7 +247,7 @@ elf32_extmap_add_sym (struct bfd_link_hash_entry *entry, void * link_info ATTRIB
    lang_output_section_statement_type from ld/ldlang.h. After 64 bytes,
    we have a pointer to lang_memory_region_type, which contains the region name as first element */
 typedef struct tricore_user_section_struct {
-  int unused[16];
+  int padding[16];
   const char **region_name;
 } tricore_section_userdata_type;
 
@@ -359,7 +359,7 @@ elf32_collect_extmap_info (struct bfd_link_info* info,
         {
 	  tricore_section_userdata_type *ud;
           ud = bfd_section_userdata(sym->section->output_section);
-          if (ud)
+          if (ud && ud->region_name)
             sym->region_name = *ud->region_name;
           else
             sym->region_name = "NOREGION";


### PR DESCRIPTION
When parsing section data for priting extended map information in map file, function elf32_collect_extmap_info was trying to retrieve region_name from the userdata field of bfd_section.

extmap module has an internal representation of the userdata field not up to date with latest ld code, which writes a lang_output_section_statement_type inside this userdata field. So if user generates map file during executable linking, the extended map table was printing gargage as memory region name, like shown here:

```
0x800001f4 0x800001f4    0 g IfxCpu_Trap_vectorTable0_end                        .traptab_tc0 .traptab_cpu0                                      third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Cpu/Trap/IfxCpu_Trap.c.obj
0x80000200 0x80000213   20 g __thenan_df                                  ���VUU .rodata      .rodata                                            _thenan_df.o
0x80000214 0x8000021b    8 l IfxScuCcu_defaultFlashWaitstateConfig        ���VUU .rodata      .rodata.IfxScuCcu_defaultFlashWaitstateConfig      third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000021c 0x80000233   24 l IfxScuCcu_defaultPllConfigSteps              ���VUU .rodata      .rodata.IfxScuCcu_defaultPllConfigSteps            third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x80000234 0x8000024b   24 g IfxScuCcu_MA_percent                         ���VUU .rodata      .rodata.IfxScuCcu_MA_percent                       third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000024c 0x8000029b   80 g IfxScuCcu_defaultClockConfig                 ���VUU .rodata      .rodata.IfxScuCcu_defaultClockConfig               third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000029c 0x800002a3    8 g IfxScuCcu_defaultModConfig                   ���VUU .rodata      .rodata.IfxScuCcu_defaultModConfig                 third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x800002a4 0x800002a4    0 g __clear_table                                ���VUU .rodata      .rodata                                            src/aurix_sample_tc33x.elf
0x800002fc 0x800002fc    0 g __copy_table                                 ���VUU .rodata      .rodata                                            src/aurix_sample_tc33x.elf
```
To fix region name parsing, this code adds additional padding in the internal struct to be able to retrieve region name from userdata field. Now memory region name should be correctly written in extended map listing:

```
0x800001f4 0x800001f4    0 g IfxCpu_Trap_vectorTable0_end                 pfls0     .traptab_tc0 .traptab_cpu0                                      third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Cpu/Trap/IfxCpu_Trap.c.obj
0x80000200 0x80000213   20 g __thenan_df                                  pfls0     .rodata      .rodata                                            _thenan_df.o
0x80000214 0x8000021b    8 l IfxScuCcu_defaultFlashWaitstateConfig        pfls0     .rodata      .rodata.IfxScuCcu_defaultFlashWaitstateConfig      third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000021c 0x80000233   24 l IfxScuCcu_defaultPllConfigSteps              pfls0     .rodata      .rodata.IfxScuCcu_defaultPllConfigSteps            third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x80000234 0x8000024b   24 g IfxScuCcu_MA_percent                         pfls0     .rodata      .rodata.IfxScuCcu_MA_percent                       third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000024c 0x8000029b   80 g IfxScuCcu_defaultClockConfig                 pfls0     .rodata      .rodata.IfxScuCcu_defaultClockConfig               third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x8000029c 0x800002a3    8 g IfxScuCcu_defaultModConfig                   pfls0     .rodata      .rodata.IfxScuCcu_defaultModConfig                 third_party/CMakeFiles/InfineonLib.dir/infineon/Libraries/iLLD/TC33A/Tricore/Scu/Std/IfxScuCcu.c.obj
0x800002a4 0x800002a4    0 g __clear_table                                pfls0     .rodata      .rodata                                            src/aurix_sample_tc33x.elf
0x800002fc 0x800002fc    0 g __copy_table                                 pfls0     .rodata      .rodata                                            src/aurix_sample_tc33x.elf
```